### PR TITLE
Add format option

### DIFF
--- a/archive-tar-external.gemspec
+++ b/archive-tar-external.gemspec
@@ -3,7 +3,7 @@ require 'rbconfig'
 
 Gem::Specification.new do |spec|
   spec.name       = 'archive-tar-external'
-  spec.version    = '1.4.2'
+  spec.version    = '1.5.0'
   spec.summary    = 'A simple way to create tar archives using external calls'
   spec.license    = 'Apache-2.0'
   spec.author     = 'Daniel Berger'

--- a/lib/archive/tar/external.rb
+++ b/lib/archive/tar/external.rb
@@ -17,7 +17,7 @@ module Archive
     # This class encapsulates tar & zip operations.
     class Tar::External
       # The version of the archive-tar-external library.
-      VERSION = '1.4.2'
+      VERSION = '1.5.0'
 
       # The name of the archive file to be used, e.g. "test.tar"
       attr_accessor :archive_name

--- a/lib/archive/tar/external.rb
+++ b/lib/archive/tar/external.rb
@@ -22,27 +22,35 @@ module Archive
       # The name of the archive file to be used, e.g. "test.tar"
       attr_accessor :archive_name
 
-      # The name of the tar program you wish to use.  The default is "tar".
+      # The name of the tar program you wish to use. The default is "tar".
       attr_accessor :tar_program
 
       # The name of the archive file after compression, e.g. "test.tar.gz"
       attr_reader :compressed_archive_name
 
-      # Returns an Archive::Tar::External object.  The +archive_name+ is the
-      # name of the tarball.  While a .tar extension is recommended based on
+      # The format of the archive file. The default is "pax".
+      attr_reader :format
+
+      # Returns an Archive::Tar::External object. The +archive_name+ is the
+      # name of the tarball. While a .tar extension is recommended based on
       # years of convention, it is not enforced.
       #
       # Note that this does not actually create the archive unless you
-      # pass a value to +file_pattern+.  This then becomes a shortcut for
+      # pass a value to +file_pattern+. This then becomes a shortcut for
       # Archive::Tar::External.new + Archive::Tar::External#create_archive.
       #
       # If +program+ is provided, then it compresses the archive as well by
       # calling Archive::Tar::External#compress_archive internally.
       #
-      def initialize(archive_name, file_pattern = nil, program = nil)
+      # You may also specify an archive format. As of version 1.5, the
+      # default is 'pax'. Previous versions used whatever your tar program
+      # used by default.
+      #
+      def initialize(archive_name, file_pattern = nil, program = nil, format = 'pax')
         @archive_name            = archive_name.to_s
         @compressed_archive_name = nil
         @tar_program             = 'tar'
+        @format                  = 'pax'
 
         create_archive(file_pattern) if file_pattern
         compress_archive(program) if program
@@ -67,12 +75,13 @@ module Archive
       end
 
       # Creates the archive using +file_pattern+ using +options+ or 'cf'
-      # (create file) by default.
+      # (create file) by default. The 'f' option should always be present
+      # and always be last.
       #
       # Raises an Archive::Tar::Error if a failure occurs.
       #
       def create_archive(file_pattern, options = 'cf')
-        cmd = "#{@tar_program} #{options} #{@archive_name} #{file_pattern}"
+        cmd = "#{@tar_program} --format #{@format} -#{options} #{@archive_name} #{file_pattern}"
 
         Open3.popen3(cmd) do |_tar_in, _tar_out, tar_err|
           err = tar_err.gets

--- a/spec/archive_tar_external_spec.rb
+++ b/spec/archive_tar_external_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Archive::Tar::External do
   end
 
   example "version" do
-    expect(Archive::Tar::External::VERSION).to eq('1.4.2')
+    expect(Archive::Tar::External::VERSION).to eq('1.5.0')
     expect(Archive::Tar::External::VERSION).to be_frozen
   end
 

--- a/spec/archive_tar_external_spec.rb
+++ b/spec/archive_tar_external_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Archive::Tar::External do
       expect{ tar_obj.create_archive('*.blah') }.to raise_error(Archive::Tar::Error)
     end
 
-    example "create_archive accepts optional parameters", :stuff => true do
+    example "create_archive accepts optional parameters" do
       expect{ tar_obj.create_archive(pattern, 'jcf') }.not_to raise_error
     end
 

--- a/spec/archive_tar_external_spec.rb
+++ b/spec/archive_tar_external_spec.rb
@@ -107,6 +107,11 @@ RSpec.describe Archive::Tar::External do
       expect(tar_obj).to respond_to(:create)
       expect(tar_obj.method(:create)).to eq(tar_obj.method(:create_archive))
     end
+
+    example "format getter" do
+      expect(tar_obj).to respond_to(:format)
+      expect(tar_obj.format).to eq('pax')
+    end
   end
 
   context "compression" do

--- a/spec/archive_tar_external_spec.rb
+++ b/spec/archive_tar_external_spec.rb
@@ -15,13 +15,11 @@ RSpec.describe Archive::Tar::External do
   let(:tar_name) { 'test.tar' }
   let(:tar_obj)  { Archive::Tar::External.new(tar_name) }
   let(:pattern)  { '*.txt' }
-  let(:gtar)     { File.basename(File.which('gtar')) }
 
   let(:archive_name) { 'test.tar.gz' }
-  let(:tar_program)  { gtar || 'tar' }
+  let(:tar_program)  { 'tar' }
 
   before do
-    tar_obj.tar_program = 'gtar' if File.which('gtar')
     File.open(tmp_file1, 'w'){ |f| f.puts 'This is a temporary text file' }
     File.open(tmp_file2, 'w'){ |f| f.puts 'This is a temporary text file' }
     File.open(tmp_file3, 'w'){ |f| f.puts 'This is a temporary text file' }
@@ -101,8 +99,8 @@ RSpec.describe Archive::Tar::External do
       expect{ tar_obj.create_archive('*.blah') }.to raise_error(Archive::Tar::Error)
     end
 
-    example "create_archive accepts optional parameters" do
-      expect{ tar_obj.create_archive(pattern, 'cfj') }.not_to raise_error
+    example "create_archive accepts optional parameters", :stuff => true do
+      expect{ tar_obj.create_archive(pattern, 'jcf') }.not_to raise_error
     end
 
     example "create is an alias for create_archive" do
@@ -185,7 +183,7 @@ RSpec.describe Archive::Tar::External do
       expect(tar_obj).to respond_to(:update_archive)
     end
 
-    example "update_archive behaves as expected", :gtar => true do
+    example "update_archive behaves as expected" do
       tar_obj.create_archive(pattern)
       expect(tar_obj.archive_info).to eq([tmp_file1, tmp_file2, tmp_file3])
       tar_obj.update_archive(tmp_file2)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,5 +3,4 @@ require 'ptools'
 
 RSpec.configure do |config|
   config.filter_run_excluding(:gzip) unless File.which('gzip')
-  config.filter_run_excluding(:gtar) unless File.which('gtar')
 end


### PR DESCRIPTION
This adds a 4th option to the constructor, format.

By default this is set to 'pax', and will be used in the `create_archive` method.